### PR TITLE
fix(config): use CommonJS syntax for postcss and tailwind configs

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,5 @@
 /** @type {import('tailwindcss').Config} */
-export default {
+module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",


### PR DESCRIPTION
This commit fixes a bug where the PostCSS and Tailwind CSS configuration files were using ES Module syntax (`export default`) in a CommonJS project. This caused a `SyntaxError` when running the build. The files have been updated to use CommonJS syntax (`module.exports`).