### PR TITLE
fix(build): inject page manifest via Vite define

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 # Build artifacts
 /dist
-/.generated
 /tmp
 
 # Log files

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,24 @@
 import React, { useState, useMemo } from 'react';
 import { Search, LayoutGrid } from 'lucide-react';
 import PageCard from '../components/PageCard';
-import manifest from '../../.generated/pages.manifest.json';
+
+// The __PAGES_MANIFEST__ global is injected by Vite.
+// We declare it here for TypeScript to recognize it.
+declare const __PAGES_MANIFEST__: PageMeta[];
 
 interface PageMeta {
   id: string;
   route: string;
   title: string;
-  summary: string;
+  summary:string;
   tags: string[];
 }
 
 const DashboardPage: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState('');
+
+  // Use the injected global variable
+  const manifest = __PAGES_MANIFEST__;
 
   const filteredPages = useMemo(() => {
     if (!searchQuery) {
@@ -24,7 +30,7 @@ const DashboardPage: React.FC = () => {
       page.summary.toLowerCase().includes(lowerCaseQuery) ||
       page.tags.some(tag => tag.toLowerCase().includes(lowerCaseQuery))
     );
-  }, [searchQuery]);
+  }, [searchQuery, manifest]);
 
   return (
     <div className="min-h-screen bg-slate-50">

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,10 +2,10 @@ const { defineConfig } = require('vite');
 const react = require('@vitejs/plugin-react');
 const { resolve, basename } = require('path');
 const { globSync } = require('glob');
-const { readFileSync, writeFileSync, mkdirSync, existsSync } = require('fs');
+const { readFileSync } = require('fs');
 
 // --- Start of manifest generation logic ---
-function generateManifest() {
+function getManifestData() {
   const files = globSync('./src/pages/samples/qo_*.tsx');
   const manifest = [];
 
@@ -33,16 +33,10 @@ function generateManifest() {
   }
 
   manifest.sort((a, b) => a.title.localeCompare(b.title));
-
-  const outputDir = resolve(__dirname, '.generated');
-  if (!existsSync(outputDir)) {
-    mkdirSync(outputDir, { recursive: true });
-  }
-  writeFileSync(resolve(outputDir, 'pages.manifest.json'), JSON.stringify(manifest, null, 2));
-  console.log('Successfully generated pages.manifest.json in vite.config.js');
+  return manifest;
 }
 
-generateManifest();
+const manifestData = getManifestData();
 // --- End of manifest generation logic ---
 
 
@@ -55,6 +49,9 @@ const entries = Object.fromEntries(
 
 module.exports = defineConfig({
   plugins: [react()],
+  define: {
+    '__PAGES_MANIFEST__': JSON.stringify(manifestData)
+  },
   build: {
     rollupOptions: {
       input: {


### PR DESCRIPTION
This commit provides a robust fix for the build error: "Failed to resolve import ../../.generated/pages.manifest.json".

The previous approach of generating a JSON file at build time was unreliable due to file system issues in the execution environment.

This new solution bypasses the file system entirely:
1. The page manifest data is now generated as an in-memory array within `vite.config.js`.
2. This data is injected directly into the client-side application as a global `__PAGES_MANIFEST__` variable using Vite's `define` feature.
3. The dashboard page (`src/app/page.tsx`) now sources its data from this global variable instead of a JSON file import.

This approach is more resilient and completely resolves the file-not-found error.