### PR TITLE
fix(config): update postcss config to use @tailwindcss/postcss

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
+    '@tailwindcss/postcss': {},
+    'autoprefixer': {},
   },
 }


### PR DESCRIPTION
This commit updates the `postcss.config.js` to correctly reference the new `@tailwindcss/postcss` package.

The previous configuration was using the key `tailwindcss`, which is no longer valid for the PostCSS plugin in recent versions of Tailwind CSS. This change aligns the configuration with the new package, resolving the build error.