### PR TITLE
refactor(app): convert to single-page application

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "lucide-react": "^0.542.0",
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^7.8.2"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.13",
@@ -19,6 +20,7 @@
         "@types/node": "^24.3.1",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
+        "@types/react-router-dom": "^5.3.3",
         "@vitejs/plugin-react": "^5.0.2",
         "autoprefixer": "^10.4.21",
         "glob": "^11.0.3",
@@ -1576,6 +1578,13 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -1611,6 +1620,29 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1821,6 +1853,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/create-require": {
       "version": "1.1.1",
@@ -2661,6 +2702,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.8.2.tgz",
+      "integrity": "sha512-7M2fR1JbIZ/jFWqelpvSZx+7vd7UlBTfdZqf6OSdF9g6+sfdqJDAWcak6ervbHph200ePlu+7G8LdoiC3ReyAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.8.2.tgz",
+      "integrity": "sha512-Z4VM5mKDipal2jQ385H6UBhiiEDlnJPx6jyWsTYoZQdl5TrjxEV2a9yl3Fi60NBJxYzOTGTTHXPi0pdizvTwow==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.8.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.50.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.50.0.tgz",
@@ -2717,6 +2796,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "dependencies": {
     "lucide-react": "^0.542.0",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^7.8.2"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.13",
@@ -32,6 +33,7 @@
     "@types/node": "^24.3.1",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
+    "@types/react-router-dom": "^5.3.3",
     "@vitejs/plugin-react": "^5.0.2",
     "autoprefixer": "^10.4.21",
     "glob": "^11.0.3",

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Routes, Route } from 'react-router-dom';
+import DashboardPage from './page';
+
+// Import all the sample pages
+import Qo_c001_landing from '../pages/samples/qo_c001_landing';
+import Qo_c002_menu from '../pages/samples/qo_c002_menu';
+import Qo_c003_item_details from '../pages/samples/qo_c003_item_details';
+import Qo_c004_cart from '../pages/samples/qo_c004_cart';
+import Qo_c005_checkout from '../pages/samples/qo_c005_checkout';
+import Qo_c006_payment from '../pages/samples/qo_c006_payment';
+import Qo_c007_order_status from '../pages/samples/qo_c007_order_status';
+import Qo_c008_confirmation from '../pages/samples/qo_c008_confirmation';
+import Qo_s001_staff_login from '../pages/samples/qo_s001_staff_login';
+import Qo_s002_dashboard from '../pages/samples/qo_s002_dashboard';
+import Qo_s003_order_management from '../pages/samples/qo_s003_order_management';
+import Qo_s004_kitchen_display from '../pages/samples/qo_s004_kitchen_display';
+import Qo_s005_menu_management from '../pages/samples/qo_s005_menu_management';
+import Qo_s006_table_management from '../pages/samples/qo_s006_table_management';
+import Qo_s007_customer_service from '../pages/samples/qo_s007_customer_service';
+import Qo_s008_staff_analytics from '../pages/samples/qo_s008_staff_analytics';
+
+const AppRouter = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<DashboardPage />} />
+      <Route path="/samples/qo_c001_landing" element={<Qo_c001_landing />} />
+      <Route path="/samples/qo_c002_menu" element={<Qo_c002_menu />} />
+      <Route path="/samples/qo_c003_item_details" element={<Qo_c003_item_details />} />
+      <Route path="/samples/qo_c004_cart" element={<Qo_c004_cart />} />
+      <Route path="/samples/qo_c005_checkout" element={<Qo_c005_checkout />} />
+      <Route path="/samples/qo_c006_payment" element={<Qo_c006_payment />} />
+      <Route path="/samples/qo_c007_order_status" element={<Qo_c007_order_status />} />
+      <Route path="/samples/qo_c008_confirmation" element={<Qo_c008_confirmation />} />
+      <Route path="/samples/qo_s001_staff_login" element={<Qo_s001_staff_login />} />
+      <Route path="/samples/qo_s002_dashboard" element={<Qo_s002_dashboard />} />
+      <Route path="/samples/qo_s003_order_management" element={<Qo_s003_order_management />} />
+      <Route path="/samples/qo_s004_kitchen_display" element={<Qo_s004_kitchen_display />} />
+      <Route path="/samples/qo_s005_menu_management" element={<Qo_s005_menu_management />} />
+      <Route path="/samples/qo_s006_table_management" element={<Qo_s006_table_management />} />
+      <Route path="/samples/qo_s007_customer_service" element={<Qo_s007_customer_service />} />
+      <Route path="/samples/qo_s008_staff_analytics" element={<Qo_s008_staff_analytics />} />
+    </Routes>
+  );
+};
+
+export default AppRouter;

--- a/src/components/PageCard.tsx
+++ b/src/components/PageCard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { ArrowRight, Tag } from 'lucide-react';
 
 interface PageCardProps {
@@ -11,8 +12,8 @@ interface PageCardProps {
 
 const PageCard: React.FC<PageCardProps> = ({ route, title, summary, tags }) => {
   return (
-    <a
-      href={route}
+    <Link
+      to={route}
       className="group flex flex-col justify-between bg-white rounded-xl shadow-sm border border-slate-200 hover:shadow-lg hover:border-slate-300 hover:-translate-y-1 transition-all duration-300 ease-in-out"
     >
       <div className="p-6">
@@ -33,7 +34,7 @@ const PageCard: React.FC<PageCardProps> = ({ route, title, summary, tags }) => {
         </span>
         <ArrowRight className="w-4 h-4 ml-2 text-slate-500 group-hover:text-slate-900 group-hover:translate-x-1 transition-transform" />
       </div>
-    </a>
+    </Link>
   );
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import App from './app/page'
+import { BrowserRouter } from 'react-router-dom'
+import App from './app/Router'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,7 +11,7 @@ function getManifestData() {
 
   for (const file of files) {
     const id = basename(file, '.tsx');
-    const route = `./${id}.html`;
+    const route = `/samples/${id}`; // New route format for the SPA
     let title = id.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
     let summary = 'A sample page for Viatable.';
     let tags = [];
@@ -39,14 +39,6 @@ function getManifestData() {
 const manifestData = getManifestData();
 // --- End of manifest generation logic ---
 
-
-const entries = Object.fromEntries(
-  globSync('./src/pages/samples/qo_*.tsx').map(file => [
-    basename(file, '.tsx'),
-    resolve(__dirname, file)
-  ])
-);
-
 module.exports = defineConfig({
   plugins: [react()],
   define: {
@@ -54,9 +46,9 @@ module.exports = defineConfig({
   },
   build: {
     rollupOptions: {
+      // Single entry point for an SPA
       input: {
         main: resolve(__dirname, 'index.html'),
-        ...entries
       }
     }
   }


### PR DESCRIPTION
This commit refactors the project from a multi-page app (MPA) structure to a standard Single-Page Application (SPA) using `react-router-dom`.

This was done to resolve persistent issues with links not working in the development environment. The MPA setup was proving unreliable.

The key changes include:
- Added `react-router-dom` dependency.
- Updated `vite.config.js` to a standard SPA configuration with a single entry point.
- Created a central `src/app/Router.tsx` to define all application routes.
- Wrapped the application in `<BrowserRouter>` in `src/main.tsx`.
- Converted navigation links in the `PageCard` component to use the `<Link>` component from `react-router-dom`.

This new architecture is more robust, aligns with modern React best practices, and should permanently fix the linking problems.